### PR TITLE
Standardize on 'Daily Target' across the app

### DIFF
--- a/Medication/InventoryView.swift
+++ b/Medication/InventoryView.swift
@@ -94,9 +94,9 @@ public struct InventoryView: View {
                             
                             VStack(alignment: .leading, spacing: 8) {
                                 HStack {
-                                    Text("Daily usage rate:")
+                                    Text("Daily Target:")
                                     Spacer()
-                                    Text(String(format: "%.1f", inventory.dailyUsageRate))
+                                    Text("\(settings.dailyPillTarget)")
                                         .fontWeight(.medium)
                                     Text("pills/day")
                                         .fontWeight(.medium)

--- a/Medication/Models.swift
+++ b/Medication/Models.swift
@@ -143,9 +143,10 @@ public class InventoryModel: ObservableObject {
         // Load usage rate
         inventory.dailyUsageRate = UserDefaults.standard.double(forKey: "inventoryDailyUsageRate")
         
-        // If no usage rate is set, default to a reasonable value (1.0 pills per day)
+        // If no usage rate is set, default to the daily target
+        let settings = SettingsModel()
         if inventory.dailyUsageRate == 0 {
-            inventory.dailyUsageRate = 1.0
+            inventory.dailyUsageRate = Double(settings.dailyPillTarget)
             inventory.save()
         }
         
@@ -166,7 +167,7 @@ public class InventoryModel: ObservableObject {
     }
     
     // Log a refill received
-    public func logRefillReceived(pillCount: Int) {
+    public func logRefillReceived(pillCount: Int, settings: SettingsModel) {
         let newEvent = RefillEvent(
             timestamp: Date(),
             eventType: .received,
@@ -178,8 +179,8 @@ public class InventoryModel: ObservableObject {
         // Update the pill count
         self.currentPillCount = pillCount
         
-        // Recalculate the daily usage rate based on historical data
-        updateDailyUsageRate()
+        // Update the daily usage rate based on settings
+        updateDailyUsageRate(settings: settings)
         
         save()
     }
@@ -192,15 +193,10 @@ public class InventoryModel: ObservableObject {
         }
     }
     
-    // Calculate daily usage rate based on medication logs
-    private func updateDailyUsageRate() {
-        // This is a simplified implementation
-        // In a real app, you would analyze medication logs over time to calculate usage rate
-        
-        // Here we'll just use a hardcoded value of 1.0 if none is set
-        if dailyUsageRate <= 0 {
-            dailyUsageRate = 1.0
-        }
+    // Calculate daily usage rate based on settings
+    public func updateDailyUsageRate(settings: SettingsModel) {
+        // Use the daily target from settings
+        dailyUsageRate = Double(settings.dailyPillTarget)
         
         save()
     }

--- a/Medication/RefillReminderManager.swift
+++ b/Medication/RefillReminderManager.swift
@@ -73,7 +73,7 @@ public class RefillReminderManager {
     // Log a refill received and reset reminders
     public func handleRefillReceived(pillCount: Int) {
         // Log the refill
-        inventory.logRefillReceived(pillCount: pillCount)
+        inventory.logRefillReceived(pillCount: pillCount, settings: settings)
         
         // Remove all pending refill notifications
         removeAllRefillNotifications()

--- a/Medication/SimpleInventoryView.swift
+++ b/Medication/SimpleInventoryView.swift
@@ -34,9 +34,9 @@ public struct SimpleInventoryView: View {
                 }
                 
                 HStack {
-                    Text("Daily usage rate:")
+                    Text("Daily Target:")
                     Spacer()
-                    Text(String(format: "%.1f", inventory.dailyUsageRate))
+                    Text("\(settings.dailyPillTarget)")
                 }
                 
                 HStack {

--- a/MedicationTests/InventoryModelTests.swift
+++ b/MedicationTests/InventoryModelTests.swift
@@ -51,13 +51,14 @@ final class InventoryModelTests: XCTestCase {
         XCTAssertEqual(inventory.currentPillCount, 30)
         
         // When
-        inventory.logRefillReceived(pillCount: 60)
+        inventory.logRefillReceived(pillCount: 60, settings: settings)
         
         // Then
         XCTAssertEqual(inventory.refillEvents.count, 1)
         XCTAssertEqual(inventory.currentPillCount, 60)
         XCTAssertEqual(inventory.refillEvents[0].eventType, .received)
         XCTAssertEqual(inventory.refillEvents[0].pillCount, 60)
+        XCTAssertEqual(inventory.dailyUsageRate, Double(settings.dailyPillTarget))
     }
     
     func testLogMedicationTaken() {

--- a/MedicationTests/RefillReminderManagerTests.swift
+++ b/MedicationTests/RefillReminderManagerTests.swift
@@ -149,6 +149,7 @@ final class RefillReminderManagerTests: XCTestCase {
         XCTAssertEqual(inventory.refillEvents[1].eventType, .received)
         XCTAssertEqual(inventory.refillEvents[1].pillCount, 60)
         XCTAssertEqual(inventory.currentPillCount, 60)
+        XCTAssertEqual(inventory.dailyUsageRate, Double(settings.dailyPillTarget))
         
         // All refill notifications should be removed
         XCTAssertTrue(mockNotificationCenter.removedIdentifiers.contains("inventoryRefillReminder"))


### PR DESCRIPTION
- Renamed 'Daily usage rate' to 'Daily Target' in inventory views
- Modified InventoryModel to use settings.dailyPillTarget as the dailyUsageRate
- Updated logRefillReceived to take settings parameter
- Updated tests to match new method signatures
- Ensured consistent terminology across the app

🤖 Generated with [Claude Code](https://claude.ai/code)
Co-Authored-By: Claude <noreply@anthropic.com>